### PR TITLE
Tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This project is a work in progress.
-
 # Introduction
 
 The motivation for this project is partly autodidactic and partly a desire to build

--- a/src/per_object_permissions/api/main.py
+++ b/src/per_object_permissions/api/main.py
@@ -33,18 +33,18 @@ def get_backend() -> protocols.PerObjectPermissionBackend:
 async def create_perms(perms: List[schema.PermTriple]):
     backend = get_backend()
     created_perms = await backend.create(perms)
-    return {"created": [perm._asdict() for perm in created_perms]}
+    return {"created": [schema.PermTriple.from_orm(perm) for perm in created_perms]}
 
 
 @app.post("/read-perms", response_model=schema.ReadResults)
 async def read_perms(query: schema.PermQuery):
     backend = get_backend()
     perms = await backend.read(**query.dict())
-    return {"results": [perm._asdict() for perm in perms]}
+    return {"results": [schema.PermTriple.from_orm(perm) for perm in perms]}
 
 
 @app.post("/delete-perms", response_model=schema.DeleteResults)
 async def delete_perms(query: schema.PermQuery):
     backend = get_backend()
     perms = await backend.delete(**query.dict())
-    return {"deleted": [perm._asdict() for perm in perms]}
+    return {"deleted": [schema.PermTriple.from_orm(perm) for perm in perms]}

--- a/src/per_object_permissions/api/schema.py
+++ b/src/per_object_permissions/api/schema.py
@@ -9,6 +9,9 @@ class PermTriple(pydantic.BaseModel):
     predicate: str
     object_uuid: uuid.UUID
 
+    class Config:
+        orm_mode = True
+
 
 class PermQuery(pydantic.BaseModel):
     subject_uuids: Optional[List[uuid.UUID]]

--- a/src/per_object_permissions/api/schema.py
+++ b/src/per_object_permissions/api/schema.py
@@ -10,7 +10,7 @@ class PermTriple(pydantic.BaseModel):
     object_uuid: uuid.UUID
 
     class Config:
-        orm_mode = True
+        orm_mode = True  # Allows creating from object attributes using from_orm
 
 
 class PermQuery(pydantic.BaseModel):


### PR DESCRIPTION
- Remove WiP text from README
- Stop directly depending of namedtuple behaviour when serialising perm triples